### PR TITLE
Align AdSense slot configuration

### DIFF
--- a/components/AdBanner.jsx
+++ b/components/AdBanner.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { ADSENSE_CLIENT_ID, ADSENSE_SLOT_ID } from "./adConfig";
 
 export default function AdBanner() {
   useEffect(() => {
@@ -13,8 +14,8 @@ export default function AdBanner() {
     <ins
       className="adsbygoogle"
       style={{ display: "block" }}
-      data-ad-client="ca-pub-8531177897035530"
-      data-ad-slot="2583059282"
+      data-ad-client={ADSENSE_CLIENT_ID}
+      data-ad-slot={ADSENSE_SLOT_ID}
       data-ad-format="auto"
       data-full-width-responsive="true"
     ></ins>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,4 +1,5 @@
 import Script from "next/script";
+import { ADSENSE_CLIENT_ID, ADSENSE_SLOT_ID } from "./adConfig";
 
 export default function Layout({ children }) {
   return (
@@ -6,7 +7,7 @@ export default function Layout({ children }) {
       {/* Script AdSense globale: caricato una sola volta */}
       <Script
         async
-        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8531177897035530"
+        src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT_ID}`}
         crossOrigin="anonymous"
         strategy="afterInteractive"
       />
@@ -31,8 +32,8 @@ export default function Layout({ children }) {
           <ins
             className="adsbygoogle"
             style={{ display: "block" }}
-            data-ad-client="ca-pub-8531177897035530"
-            data-ad-slot="1234567890"   // <-- sostituisci con il tuo slot ID
+            data-ad-client={ADSENSE_CLIENT_ID}
+            data-ad-slot={ADSENSE_SLOT_ID}
             data-ad-format="auto"
             data-full-width-responsive="true"
           ></ins>

--- a/components/adConfig.js
+++ b/components/adConfig.js
@@ -1,0 +1,2 @@
+export const ADSENSE_CLIENT_ID = "ca-pub-8531177897035530";
+export const ADSENSE_SLOT_ID = "2583059282";


### PR DESCRIPTION
## Summary
- add a shared AdSense configuration module with the real client and slot IDs
- update Layout and AdBanner to reference the shared constants so the default slot uses 2583059282

## Testing
- npm run dev (visited http://localhost:3000/staking to verify the ad slot renders with 2583059282)


------
https://chatgpt.com/codex/tasks/task_e_68d931bc7dec832dbbc5f601dfec1f1f